### PR TITLE
Untitled

### DIFF
--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -354,6 +354,7 @@ sub _write_psgi_response {
             if ( eval { $_[0]->recv; 1 } ) {
                 $self->_write_body($sock, $body)->cb(sub {
                     shutdown $sock, 1;
+                    close $sock;
                     $self->{exit_guard}->end;
                     local $@;
                     eval { $cv->send($_[0]->recv); 1 } or $cv->croak($@);

--- a/t/anyevent_manyconnections.t
+++ b/t/anyevent_manyconnections.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    plan skip_all => 'Slow test skipped unless $ENV{TEST_SLOW} is set'
+        unless $ENV{TEST_SLOW};
+}
+
+use Plack::Test::Suite;
+use AnyEvent;
+
+use HTTP::Request;
+use HTTP::Request::Common;
+
+my $LOOPS = 1024; # Default max fds on linux.
+
+sub gentest {
+    my $name = shift;
+    return ($name, sub {
+        my $cb = shift;
+        for (1..$LOOPS) {
+            alarm 2;
+            local $SIG{ALRM} = sub {
+                fail("Timed out");
+                exit;
+            };
+            my $res = $cb->(GET "http://127.0.0.1/");
+            is $res->code, 200, "$name $_ of $LOOPS";
+            alarm 0;
+        }
+    });
+}
+
+local @Plack::Test::Suite::TEST = (
+    [
+        gentest('BadResponse'),
+        sub {
+            return [
+                200,
+                [ 'Content-Type' => 'text/plain', ],
+                'Hello'
+            ];
+        },
+    ],
+    [
+        gentest('GoodResponse'),
+        sub {
+            return [
+                200,
+                [ 'Content-Type' => 'text/plain', ],
+                ['Hello']
+            ];
+        },
+    ],
+);
+
+# prevent Lint middleware from being used
+Plack::Test::Suite->run_server_tests(sub {
+    my($port, $app) = @_;
+    my $server = Plack::Loader->load("Twiggy", port => $port, host => "127.0.0.1");
+    $server->run($app);
+});
+
+done_testing();
+


### PR DESCRIPTION
Change to stop leaking fds in some cases by explicitly closing the socket - this is noticeable if you use Catalyst::Engine::PSGI also.

It's possible that sockets should be closed in some other places to be extra-careful also, however this is the one that's biting my specific application, and the only one that I managed to demonstrate an issue with (breaks on both Linux and MacOS for me).
