### PR TITLE
Suppress 400 if client disconnected

### DIFF
--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -160,7 +160,7 @@ sub _accept_handler {
 
             1;
         }) {
-            $self->_bad_request($sock) unless $@ eq 'client disconnected';
+            $self->_bad_request($sock) unless $@ =~ /^client disconnected/;
         }
     };
 }
@@ -217,7 +217,7 @@ sub _create_req_parsing_watcher {
         } catch {
             undef $headers_io_watcher;
             undef $timeout_timer;
-            $self->_bad_request($sock) unless $_ eq 'client disconnected';
+            $self->_bad_request($sock) unless /^client disconnected/;
         }
     };
 }


### PR DESCRIPTION
This patch prevents sending a 400 response if client disconnection was detected. See https://github.com/miyagawa/Twiggy/issues/17.
