### PR TITLE
Don't restrict parsing the request body to PUT and POST requests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension Twiggy
 
+        - Don't restrict parsing the request body to PUT and POST requests
+
 0.1010 Mon Jan 17 17:04:14 PST 2011
         - Returning CondVar as a PSGI response is deprecated. Will be removed in the next release
 

--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -292,7 +292,7 @@ sub _run_app {
     my($self, $app, $env, $sock) = @_;
 
     unless ($env->{'psgi.input'}) {
-        if ($env->{CONTENT_LENGTH} && $env->{REQUEST_METHOD} =~ /^(?:POST|PUT)$/) {
+        if ($env->{CONTENT_LENGTH}) {
             $self->_read_chunk($sock, $env->{CONTENT_LENGTH}, sub {
                 my ($data) = @_;
                 open my $input, '<', \$data;


### PR DESCRIPTION
I use Twiggy as a proxy in front of ElasticSearch. ES allows both GET and DELETE requests with a request body. I don't see a reason why Twiggy shouldn't support this as well.
