### PR TITLE
High CPU load on terminated post data

### DIFF
--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -268,6 +268,8 @@ sub _read_chunk {
                 return 1;
             } elsif ($! and $! != EAGAIN && $! != EINTR && $! != WSAEWOULDBLOCK) {
                 die $!;
+            } elsif (!$!) {
+                die "client disconnected";
             }
         }
 


### PR DESCRIPTION
In case of termination processing of POST data Twiggy entered infinity loop.

This patch fixes high CPU load in case of terminated transmission during sending POST request data. It was described in #10.

The only sign of problem is high CPU load, so it looks impossible to write test case.
