### PR TITLE
Removed unnecessary shutdown()

### DIFF
--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -363,7 +363,6 @@ sub _write_psgi_response {
             local $@;
             if ( eval { $_[0]->recv; 1 } ) {
                 $self->_write_body($sock, $body)->cb(sub {
-                    shutdown $sock, 1;
                     close $sock;
                     $self->{exit_guard}->end;
                     local $@;


### PR DESCRIPTION
This shutdown is followed by close function. I need to delete it for Twiggy::TLS, shutdown prevent correct SSL session closing.
