### PR TITLE
Send HTTP-1.1 Responses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ Makefile
 inc/
 pm_to_blib
 *~
+.tags
+MYMETA.json
+MYMETA.yml
+blib/

--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -389,13 +389,13 @@ sub _write_headers {
 sub _format_headers {
     my ( $self, $status, $headers ) = @_;
 
-    my $hdr = sprintf "HTTP/1.0 %d %s\015\012", $status, HTTP::Status::status_message($status);
+    my $hdr = sprintf "HTTP/1.1 %d %s\015\012", $status, HTTP::Status::status_message($status);
 
     my $i = 0;
 
     my @delim = ("\015\012", ": ");
 
-    foreach my $str ( @$headers ) {
+    foreach my $str ( @$headers, qw( Connection close ) ) {
         $hdr .= $str . $delim[++$i % 2];
     }
 


### PR DESCRIPTION
- Despite not requiring the `Host` header or supporting keep-alives, send
     HTTP/1.1 response.
  - This will allow custom servers to actually use some HTTP/1.1 features,
       such as the cache-control header, even though clients are forced to
       delegate keep-alive behavior to their load-balancer.
  - When tested behind haproxy and friends, has no impact on upstream
       load-balancing.
