### PR TITLE
Ignore AnyEvent::Handler->push_write errors to prevent broken pipe error

### DIFF
--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -595,13 +595,15 @@ sub run {
 package Twiggy::Writer;
 use AnyEvent::Handle;
 
+use constant DEBUG => $ENV{TWIGGY_DEBUG};
+
 sub new {
     my ( $class, $socket, $exit ) = @_;
 
     bless { handle => AnyEvent::Handle->new( fh => $socket ), exit_guard => $exit }, $class;
 }
 
-sub write { $_[0]{handle}->push_write($_[1]) }
+sub write { eval { $_[0]{handle}->push_write($_[1]) }; warn if DEBUG && $@ }
 
 sub close {
     my $self = shift;


### PR DESCRIPTION
Twiggy with Plack::App::Proxy:

``` perl
#!/usr/bin/env twiggy

use Plack::Builder;
use Plack::App::Proxy;

builder {
    enable 'AccessLog';
    enable 'Proxy::Connect';
    enable 'Proxy::AddVia';
    enable 'Proxy::Requests';
    Plack::App::Proxy->new->to_app;
};
```

It fails often with following error:

```
127.0.0.1 - - [30/Dec/2013:22:55:16 +0100] "GET http://i.wp.pl/a/i/program_tv/logotypy/tv4.jpg HTTP/1.1" 200 - "http://tv.wp.pl/?ticaid=111ef7" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36"
AnyEvent::Handle uncaught error: Broken pipe at /home/dexter/perl5/perlbrew/perls/perl-5.18.1/lib/site_perl/5.18.1/Twiggy/Server.pm line 604.
```

It seems that this patch prevents Twiggy crashes.
