### PR TITLE
t/anyevent_closed_connection.t kills server before event loop is ready

### DIFF
--- a/t/anyevent_closed_connection.t
+++ b/t/anyevent_closed_connection.t
@@ -43,6 +43,9 @@ my $server = Test::TCP->new(
     auto_start => 1,
 );
 
+# wait a second for server start
+sleep(1);
+
 request($server->port);
 
 kill 'QUIT' => $server->pid;


### PR DESCRIPTION
I was hacking Twiggy and found that the test t/anyevent_closed_connection.t kills server before server is ready to accept connection. So, the test do not test what should be tested. 
It can be simply examined with TWIGGY_DEBUG:

```
$ TWIGGY_DEBUG=1 prove -l t/anyevent_closed_connection.t
t/anyevent_closed_connection.t .. Listening on 127.0.0.1:51403
t/anyevent_closed_connection.t .. ok  
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.09 cusr  0.04 csys =  0.15 CPU)
Result: PASS
```

I added `sleep(0)` to test file. 
Now, server accepts connection, request is parsed and responder is called:

```
$ TWIGGY_DEBUG=1 prove -l t/anyevent_closed_connection.t
t/anyevent_closed_connection.t .. Listening on 127.0.0.1:51257
GLOB(0x1a4ef50) Accepted connection from 127.0.0.1:35045
GLOB(0x1a4f070) Accepted connection from 127.0.0.1:35046
GLOB(0x1a4f070) Parsed HTTP headers: request length=63
t/anyevent_closed_connection.t .. ok  
All tests successful.
Files=1, Tests=1,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.10 cusr  0.04 csys =  0.16 CPU)
Result: PASS
```

