### PR TITLE
Fix sigquit graceful shutdown

### DIFF
--- a/lib/Twiggy/Server/SS.pm
+++ b/lib/Twiggy/Server/SS.pm
@@ -20,7 +20,9 @@ sub start_listen {
     my $ports = server_ports();
     while (my ($hostport, $fd) = each %$ports ) {
         push @listen, $hostport;
-        $self->_create_ss_tcp_server($hostport, $fd, $app);
+        # listen guards are released after SIGQUIT
+        push @{$self->{listen_guards}}, 
+             $self->_create_ss_tcp_server($hostport, $fd, $app);
     }
 
     # overwrite, just in case somebody wants to refer to it afterwards

--- a/t/anyevent_server_starter_graceful.t
+++ b/t/anyevent_server_starter_graceful.t
@@ -1,0 +1,151 @@
+# Test of gaceful restart with Server::Starter
+# After SIGQUIT a new worker is spawned, old worker
+# finishes old requests but doesn't accept new ones
+use strict;
+use Test::More;
+use Test::Requires qw(Server::Starter LWP::UserAgent);
+use Test::TCP;
+use LWP::UserAgent;
+use IO::Socket::INET;
+use IO::Select;
+use Server::Starter qw/start_server/;
+
+my $server = Test::TCP->new(
+    code => sub {
+        my $port = shift;
+
+        start_server(
+            signal_on_hup => 'QUIT',
+            port          => [$port],
+            exec          => [
+                $^X,          '-Mblib',
+                '-MAnyEvent', '-MPlack::Loader',
+                '-e',         <<'_APP' ],
+        Plack::Loader->load( 'Twiggy', host => '127.0.0.1' )
+            ->run(
+            sub {
+                my $env = shift;
+
+                my (undef, $sockname, $delay) = split('/', $env->{REQUEST_URI});
+
+                return sub {
+                    my ($responder) = @_;
+
+                    my $w;
+                    $w = AE::timer $delay, 0, sub {
+                        undef $w;
+                        $responder->(
+                            [   '200', [ 'Content-Type' => 'text/plain' ],
+                                ["Sockname: $sockname\nPID: $$"]
+                            ]
+                        );
+                    };
+                    return;
+                    }
+            }
+            );
+_APP
+        );
+        exit 0;
+    }
+);
+
+ok( $server, "Server started" );
+
+sleep(2);  # let the server start
+
+my @clients;
+
+# first request with delayed response for 10 seconds
+$clients[0] =  {
+    socket => request( $server->port, 'sock0', 10 ),
+    t0 => time()
+};    
+
+sleep (1);
+
+# graceful restart
+kill 'HUP' => $server->pid;
+
+sleep(2); # let child start
+
+# second "client" should connect to a new instance
+$clients[1] =  {
+    socket => request( $server->port, 'sock1', 2 ),
+    t0 => time()
+};    
+
+
+
+# wait for responses
+read_responses( \@clients );
+
+# clients should be served from different workers
+cmp_ok(
+    $clients[0]->{pid},
+    '!=',
+    $clients[1]->{pid},
+    "Requests served with different workers"
+);
+cmp_ok( $clients[0]->{delay}, '>=', 10, "First request served last" );
+cmp_ok( $clients[1]->{delay}, '>=', 2,
+    "Second request served first" );
+
+# kill server
+kill 'TERM' => $server->pid;
+waitpid( $server->pid, 0 );
+is( $?, 0, "Server quits cleanly" );
+
+
+
+
+sub request {
+    my ( $port, $sockname, $delay ) = @_;
+    my $sock = IO::Socket::INET->new(
+        Proto    => 'tcp',
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+    ) or die "Cannot open client socket: $!";
+    $sock->autoflush;
+
+    my $req = <<_END_;
+GET /$sockname/$delay HTTP/1.0
+Host: localhost:$port
+User-Agent: hogehoge
+
+_END_
+    $req =~ s/\n/\r\n/g;
+    $sock->print($req) or die "Can't write to socket: $!";
+    $sock->shutdown(1);    # close for writing
+    return $sock;
+}
+
+
+sub read_responses {
+    my ($clients) = @_;
+
+    my @sockets = map { $_->{socket} } @$clients ;
+    my $select = IO::Select->new( @sockets );
+
+    while ( my @read = $select->can_read(20) ) {
+        for my $s (@read) {
+            $s->recv( my $data, 1024, MSG_WAITALL );
+
+            my ($p)        = $data =~ /^PID: (\d+)/m;
+            my ($sockname) = $data =~ /^Sockname: (\S+)/m;
+
+            my ($c) = grep { $_->{socket} == $s } @$clients; 
+            my $delay = time() - $c->{t0};
+            ok( $p, "Pid returned ($p) for $sockname after $delay sec" );
+            $c->{pid} = $p;
+            $c->{delay} = $delay;
+            $select->remove($s);
+            $s->close;
+        }
+    }
+
+    is($select->count, 0, "All sockets read");
+
+}
+
+done_testing;

--- a/t/twiggy_sigquit.t
+++ b/t/twiggy_sigquit.t
@@ -1,0 +1,105 @@
+# Twiggy app finishes running async request after SIGQUIT 
+# but doesn't accept new connections 
+use strict;
+use Test::More;
+use Test::Requires qw(Server::Starter LWP::UserAgent);
+use Test::TCP;
+use LWP::UserAgent;
+use IO::Socket::INET;
+use IO::Select;
+use AnyEvent;
+use Plack::Loader;
+
+my $server = Test::TCP->new(
+    code => sub {
+        my $port = shift;
+
+        Plack::Loader->load( 'Twiggy', host => '127.0.0.1', port => $port )
+            ->run(
+            sub {
+                return sub {
+                    my ($responder) = @_;
+
+                    my $w;
+                    $w = AE::timer 5, 0, sub {
+                        undef $w;
+                        $responder->(
+                            [   '200', [ 'Content-Type' => 'text/plain' ],
+                                ['Hello, Twiggy!']
+                            ]
+                        );
+                    };
+                    return;
+                    }
+            }
+            );
+        exit 0;
+    }
+);
+
+ok( $server, "Server started" );
+my $t0    = time();
+my $sock1 = request( $server->port );
+
+kill 'QUIT' => $server->pid;
+sleep(1);
+
+
+# server should not accept a new connection
+# after SIGQUIT
+my $sock2 = IO::Socket::INET->new(
+    Proto    => 'tcp',
+    PeerAddr => '127.0.0.1',
+    PeerPort => $server->port,
+);
+if ( !$sock2 ) {
+    pass("App is not listening after SIGQUIT");
+}
+else {
+    fail("App is not listening after SIGQUIT");
+    $sock2->close();
+}
+
+# the delayed request receives response
+# although server is not accepting new connections
+my $s = IO::Select->new();
+$s->add($sock1);
+my @read = $s->can_read(20);
+
+if ( $read[0] == $sock1 ) {
+    my $data;
+    $sock1->recv( $data, 1024, MSG_WAITALL );
+    like( $data, qr{Hello, Twiggy!}, "Response returned to \$socket1" );
+    cmp_ok( time() - $t0, '>=', 5, "Response with expected delay" );
+    $sock1->close();
+}
+else {
+    fail "response not returned to \$socket1";
+}
+
+waitpid( $server->pid, 0 );
+is( $?, 0, "Server quits cleanly" );
+
+
+sub request {
+    my $port = shift;
+    my $sock = IO::Socket::INET->new(
+        Proto    => 'tcp',
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+    ) or die "Cannot open client socket: $!";
+    $sock->autoflush;
+
+    my $req = <<_END_;
+GET / HTTP/1.0
+Host: localhost:$port
+User-Agent: hogehoge
+
+_END_
+    $req =~ s/\n/\r\n/g;
+    $sock->print($req);
+    $sock->shutdown(1); # shutdown for writing
+    return $sock;
+}
+
+done_testing;


### PR DESCRIPTION
This pull request solves issue #32   - "Graceful shutdown on SIGQUIT lasts forever if requests keep coming"

Current version 0.1025 releases listening ports in AE::cv callback on `$self->{exit_guard}`. This callback is never called when Twiggy is under heavy load (or delayed response) because every incoming request calls `$self->{exit_guard}->begin` when starts (and `$self->{exit_guard}->end` when finishes) and counter never drops to zero.

When SIGQUIT is caught the counter must be decreased with `$self->{exit_guard}->end` and also the array with guards (`$self->{listen_guards}`} must be released to finish listening on ports.

Twiggy::Server::SS doesn't add guards to `$self->{listen_guards}` at all when tcp servers are created.

This pull request:

* added two new tests: one for Twiggy::Server and one for Twiggy::Server::SS (these tests fail with current 0.1025 version)
* fixed SIGQUIT watcher in Twiggy::Server - release `$self->{listen_guards}` and ignore multiple SIGQUIT
* modified Twiggy::Server::SS (to keep guards in `$self->{listen_guards}`)

All tests passed (tested under CentOS and Mac OS X) and also Twiggy::Prefork tests are ok  with modified Twiggy.

The test case from issue #32 is now working as expected, running request are finished and server dies.