### PR TITLE
$exit_guard->end is missing once if getting $writer is asynchronous

### DIFF
--- a/lib/Twiggy/Server.pm
+++ b/lib/Twiggy/Server.pm
@@ -315,8 +315,6 @@ sub _run_app {
         Carp::carp("Returning AnyEvent condvar is deprecated and will be removed in the next release of Twiggy. Use the streaming callback interface intstead.");
         $res->cb(sub { $self->_write_psgi_response($sock, shift->recv) });
     } elsif ( ref $res eq 'CODE' ) {
-        my $created_writer;
-
         $res->(
             sub {
                 my $res = shift;
@@ -329,7 +327,7 @@ sub _run_app {
                     $self->_flush($sock);
 
                     my $writer = Twiggy::Writer->new($sock, $self->{exit_guard});
-                    $created_writer = 1;
+                    $self->{created_writer} = 1;
 
                     my $buf = $self->_format_headers($status, $headers);
                     $writer->write($$buf);
@@ -343,10 +341,6 @@ sub _run_app {
             },
             $sock,
         );
-
-        if($created_writer) {
-            $self->{exit_guard}->end; # normally _write_psgi_response calls this, but it doesn't get called when we use a writer!
-        }
     } else {
         croak("Unknown response type: $res");
     }
@@ -372,12 +366,12 @@ sub _write_psgi_response {
                 $self->_write_body($sock, $body)->cb(sub {
                     shutdown $sock, 1;
                     close $sock;
-                    $self->{exit_guard}->end;
+                    $self->{exit_guard}->end unless $self->{created_writer};
                     local $@;
                     eval { $cv->send($_[0]->recv); 1 } or $cv->croak($@);
                 });
             } else {
-                $self->{exit_guard}->end;
+                $self->{exit_guard}->end unless $self->{created_writer};
                 eval { $cv->send($_[0]->recv); 1 } or $cv->croak($@);
             }
         });
@@ -604,8 +598,6 @@ use AnyEvent::Handle;
 
 sub new {
     my ( $class, $socket, $exit ) = @_;
-
-    $exit->begin if $exit;
 
     bless { handle => AnyEvent::Handle->new( fh => $socket ), exit_guard => $exit }, $class;
 }

--- a/t/anyevent_ae_counter.t
+++ b/t/anyevent_ae_counter.t
@@ -2,95 +2,197 @@ use strict;
 use warnings;
 
 use Test::Requires qw(AnyEvent::HTTP PadWalker);
+use Data::Dumper;
 use HTTP::Request;
 use HTTP::Request::Common;
 use LWP::UserAgent;
-use PadWalker qw(peek_sub);
+use PadWalker qw(peek_sub closed_over);
 use Plack::Loader;
 use POSIX ();
 use Test::More;
 use Test::TCP;
+use Time::HiRes qw(usleep);
+use Twiggy::Server;
 
-sub exit_guard_end {
+sub exit_guard {
+    my ($env) = @_;
     my $exit_guard = ${peek_sub(\&Twiggy::Server::run)->{'$self'}}->{exit_guard};
-    $exit_guard->end;
+    $exit_guard->end if $env and $env->{QUERY_STRING} =~ /exit_guard_end=1/;
+    $exit_guard;
 }
 
-sub test {
-    my ($app_name, $app) = @_;
-    my $server = Test::TCP->new(
-        code => sub {
-            my ($port) = @_;
-            my $server = Plack::Loader->load('Twiggy', port => $port, host => '127.0.0.1');
-            $server->run($app);
-            exit;
-        },
-    );
-    {
-        my $port = $server->port;
-        my $ua   = LWP::UserAgent->new( timeout => 2 );
-        my $req  = GET ("http://localhost:$port/");
-        my $res  = $ua->request($req);
-        is $res->content, $app_name, "[$app_name] content is good.";
+sub do_streaming_request {
+    my ( $url, $callback ) = @_;
 
-        sleep 1;
-        my $kid = waitpid $server->pid, POSIX::WNOHANG;
-        ok $kid == $server->pid, "[$app_name] server terminated according to condvar.";
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $cond = AnyEvent->condvar;
+
+    http_get $url, timeout => 3, want_body_handle => 1, sub {
+        my ( $h, $headers ) = @_;
+
+        is $headers->{'Status'}, 200, 'streaming response should succeed';
+
+        $h->on_read(sub {
+            $h->push_read(line => sub {
+                my ( undef, $line ) = @_;
+
+                my $stop = $callback->($line, $cond);
+                if($stop) {
+                    $h->destroy;
+                    $cond->send;
+                }
+            });
+        });
+
+        $h->on_error(sub {
+            my ( undef, undef, $error ) = @_;
+
+            fail "Unexpected error: $error";
+            $h->destroy;
+            $cond->send;
+        });
+
+        $h->on_eof(sub {
+            $h->destroy;
+            $cond->send;
+        });
+    };
+    $cond->recv;
+}
+
+my $app = sub {
+    my ($env) = @_;
+
+    my $exit_guard = exit_guard($env);
+
+    if ( $env->{PATH_INFO} eq '/basic' ) {
+        [200, ['Content-Type', 'text/plain'], ["/basic"]];
     }
-}
-
-test(
-    "basic response",
-    sub {
-        exit_guard_end();
-        [200, ['Content-Type', 'text/plain'], ["basic response"]];
-    },
-);
-
-test(
-    "delayed response",
-    sub {
-        my ($env) = @_;
+    elsif ( $env->{PATH_INFO} eq '/delayed' ) {
         sub {
             my $respond = shift;
-            exit_guard_end();
-            $respond->([200, ['Content-Type', 'text/plain'], ["delayed response"]]);
+            $respond->([200, ['Content-Type', 'text/plain'], ["/delayed"]]);
         };
-    },
-);
-
-test(
-    "streaming response",
-    sub {
+    }
+    elsif ( $env->{PATH_INFO} eq '/stream1' ) {
         my ($env) = @_;
         sub {
             my $respond = shift;
             my $writer = $respond->([200, ['Content-Type', 'text/plain']]);
-            $writer->write("streaming response");
-            exit_guard_end();
+            $writer->write("/stream1");
             $writer->close;
         };
-    },
-);
-
-test(
-    "streaming response with small pause to respond",
-    sub {
-        my ($env) = @_;
+    }
+    elsif ( $env->{PATH_INFO} eq '/stream2' ) {
+        # streaming response with small pause to respond and explicitly $writer->close
         sub {
             my $respond = shift;
             my $w; $w = AnyEvent->timer(
                 after => 1,
                 cb => sub {
                     my $writer = $respond->([200, ['Content-Type', 'text/plain']]);
-                    $writer->write("streaming response with small pause to respond");
-                    exit_guard_end();
+                    $writer->write("/stream2");
                     $writer->close;
                     $w = undef;
                 },
             );
         };
-    },
-);
+    }
+    elsif ( $env->{PATH_INFO} eq '/stream3' ) {
+        # streaming response with small pause to respond and implicitly $writer->close
+        sub {
+            my $respond = shift;
+            my $w; $w = AnyEvent->timer(
+                after => 1,
+                cb => sub {
+                    my $writer = $respond->([200, ['Content-Type', 'text/plain']]);
+                    $writer->write("/stream3");
+                    #$writer->close;
+                    $w = undef;
+                },
+            );
+        };
+    }
+    elsif ( $env->{PATH_INFO} eq '/vars_clean' ) {
+        my $body = "/vars_clean";
+        my $closed_over = closed_over(\&Twiggy::Server::_write_psgi_response);
+        my $CREATED_WRITER = $closed_over->{'%CREATED_WRITER'};
+        if ( keys %$CREATED_WRITER ) {
+            $body = Dumper $closed_over;
+        }
+        [200, ['Content-Type', 'text/plain'], [$body]];
+    }
+    elsif ( $env->{PATH_INFO} eq '/10' ) {
+        sub {
+            my ( $respond ) = @_;
+
+            my $writer = $respond->( [200, ['Content-Type', 'text/plain'] ] );
+
+            foreach my $number ( 1 .. 10 ) {
+                $writer->write($number . "\n");
+                usleep 100_000;
+            }
+        };
+    }
+    else {
+        [404, ['Content-Type', 'text/plain'], ["not found $env->{PATH_INFO}"]];
+    }
+};
+
+{
+    for my $path (qw(/basic /delayed /stream1 /stream2 /stream3)) {
+        my $server = Test::TCP->new(
+            code => sub {
+                my ($port) = @_;
+                my $server = Plack::Loader->load('Twiggy', port => $port, host => '127.0.0.1');
+                $server->run($app);
+                exit;
+            },
+        );
+        my $port = $server->port;
+        my $ua   = LWP::UserAgent->new( timeout => 2 );
+        my $req  = GET ("http://localhost:$port$path?exit_guard_end=1");
+        my $res  = $ua->request($req);
+        is $res->content, $path, "[$path] content is good.";
+
+        sleep 1;
+        my $kid = waitpid $server->pid, POSIX::WNOHANG;
+        ok $kid == $server->pid, "[$path] server terminated according to condvar.";
+    }
+}
+
+{
+    my $server = Test::TCP->new(
+        code => sub {
+            my ($port) = @_;
+            my $server = Plack::Loader->load('Twiggy', port => $port, host => '127.0.0.1');
+            $server->run($app);
+        },
+    );
+    for my $path (qw(/basic /delayed /stream1 /stream2 /stream3 /vars_clean)) {
+        my $port = $server->port;
+        my $ua   = LWP::UserAgent->new( timeout => 2 );
+        my $req  = GET ("http://localhost:$port$path");
+        my $res  = $ua->request($req);
+        is $res->content, $path, "[$path] content is good.";
+    }
+
+    do_streaming_request('http://127.0.0.1:'.$server->port.'/10', sub {
+        my ( $line, $cond ) = @_;
+        if($line == 5) {
+            return 1;
+        }
+        return;
+    });
+
+    for my $path (qw(/vars_clean)) {
+        my $port = $server->port;
+        my $ua   = LWP::UserAgent->new( timeout => 2 );
+        my $req  = GET ("http://localhost:$port$path");
+        my $res  = $ua->request($req);
+        is $res->content, $path, "[$path] content is good.";
+    }
+}
 
 done_testing();

--- a/t/anyevent_ae_counter.t
+++ b/t/anyevent_ae_counter.t
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+
+use Test::Requires qw(AnyEvent::HTTP PadWalker);
+use HTTP::Request;
+use HTTP::Request::Common;
+use LWP::UserAgent;
+use PadWalker qw(peek_sub);
+use Plack::Loader;
+use POSIX ();
+use Test::More;
+use Test::TCP;
+
+sub exit_guard_end {
+    my $exit_guard = ${peek_sub(\&Twiggy::Server::run)->{'$self'}}->{exit_guard};
+    $exit_guard->end;
+}
+
+sub test {
+    my ($app_name, $app) = @_;
+    my $server = Test::TCP->new(
+        code => sub {
+            my ($port) = @_;
+            my $server = Plack::Loader->load('Twiggy', port => $port, host => '127.0.0.1');
+            $server->run($app);
+            exit;
+        },
+    );
+    {
+        my $port = $server->port;
+        my $ua   = LWP::UserAgent->new( timeout => 2 );
+        my $req  = GET ("http://localhost:$port/");
+        my $res  = $ua->request($req);
+        is $res->content, $app_name, "[$app_name] content is good.";
+
+        sleep 1;
+        my $kid = waitpid $server->pid, POSIX::WNOHANG;
+        ok $kid == $server->pid, "[$app_name] server terminated according to condvar.";
+    }
+}
+
+test(
+    "basic response",
+    sub {
+        exit_guard_end();
+        [200, ['Content-Type', 'text/plain'], ["basic response"]];
+    },
+);
+
+test(
+    "delayed response",
+    sub {
+        my ($env) = @_;
+        sub {
+            my $respond = shift;
+            exit_guard_end();
+            $respond->([200, ['Content-Type', 'text/plain'], ["delayed response"]]);
+        };
+    },
+);
+
+test(
+    "streaming response",
+    sub {
+        my ($env) = @_;
+        sub {
+            my $respond = shift;
+            my $writer = $respond->([200, ['Content-Type', 'text/plain']]);
+            $writer->write("streaming response");
+            exit_guard_end();
+            $writer->close;
+        };
+    },
+);
+
+test(
+    "streaming response with small pause to respond",
+    sub {
+        my ($env) = @_;
+        sub {
+            my $respond = shift;
+            my $w; $w = AnyEvent->timer(
+                after => 1,
+                cb => sub {
+                    my $writer = $respond->([200, ['Content-Type', 'text/plain']]);
+                    $writer->write("streaming response with small pause to respond");
+                    exit_guard_end();
+                    $writer->close;
+                    $w = undef;
+                },
+            );
+        };
+    },
+);
+
+done_testing();


### PR DESCRIPTION
Hi.

I have encountered a problem using Plack::App::Proxy.
What started with "start_server ... plackup -S Twiggy::Prefork ..." does not end with "start_server --stop".
It will be blocked.

Even in Plack::App::Proxy::Backend::AnyEvent::HTTP it may be asynchronous up to "$writer = $respond->([$status, [...]])".
https://st.aticpan.org/source/LEEDO/Plack-App-Proxy-0.29/lib/Plack/App/Proxy/Backend/AnyEvent/HTTP.pm

https://github.com/miyagawa/Twiggy/pull/41/files#diff-5131ca5d20841ad4bb47909ab0f5c25bR347 seems to be based on synchronous processing.

I prepared a test code to see whether $cv->{_ae_counter} is correctly incremented or decremented in each response.

I wrote patches so that the intended modifications in #41 work even asynchronously.

Thanks for your time.